### PR TITLE
ESWE-1877: Update dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "10.1.2"
-  kotlin("plugin.spring") version "2.3.20"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "10.2.2"
+  kotlin("plugin.spring") version "2.3.21"
 }
 
 configurations {
@@ -8,15 +8,15 @@ configurations {
 }
 
 dependencies {
-  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:2.1.0")
+  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:2.1.1")
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-webclient")
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2")
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3")
 
-  testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:2.1.0")
+  testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:2.1.1")
   testImplementation("org.springframework.boot:spring-boot-webtestclient")
   testImplementation("org.wiremock:wiremock-standalone:3.13.2")
-  testImplementation("io.swagger.parser.v3:swagger-parser:2.1.39") {
+  testImplementation("io.swagger.parser.v3:swagger-parser:2.1.40") {
     exclude(group = "io.swagger.core.v3")
   }
   testImplementation("org.awaitility:awaitility-kotlin")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -69,5 +69,3 @@ api.client:
   response-timeout: 20s
   max-retry-attempts: 3
   min-back-off-duration: 3s
-
-springdoc.swagger-ui.version: 5.32.1


### PR DESCRIPTION
Update plugin/dependencies
- HMPPS Gradle Spring Boot plugin to `10.2.2`
- Kotlin to `2.3.21`
- Spring Boot to `4.0.6`
- HMPPS Kotlin lib to `2.1.1`
- `swagger-parser` to `2.1.40`
- `springdoc-openapi-starter-webmvc-ui` to `3.0.3`
- Unpin Swagger UI