### PR TITLE
ESWE-2037: Update dependencies and Helm charts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,10 @@ configurations {
   testImplementation { exclude(group = "org.junit.vintage") }
 }
 
+ext["jackson-2-bom.version"] = "2.21.5"
+ext["log4j2.version"] = "2.25.5"
+ext["tomcat.version"] = "11.0.24"
+
 dependencies {
   implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:2.5.0")
   implementation("org.springframework.boot:spring-boot-starter-webflux")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "10.5.3"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "10.5.7"
   kotlin("plugin.spring") version "2.4.0"
 }
 
@@ -8,15 +8,15 @@ configurations {
 }
 
 dependencies {
-  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:2.2.0")
+  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:2.5.0")
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-webclient")
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3")
 
-  testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:2.2.0")
+  testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:2.5.0")
   testImplementation("org.springframework.boot:spring-boot-webtestclient")
   testImplementation("org.wiremock:wiremock-standalone:3.13.2")
-  testImplementation("io.swagger.parser.v3:swagger-parser:2.1.41") {
+  testImplementation("io.swagger.parser.v3:swagger-parser:2.1.45") {
     exclude(group = "io.swagger.core.v3")
   }
   testImplementation("org.awaitility:awaitility-kotlin")

--- a/helm_deploy/hmpps-prisoner-base-location-api/Chart.yaml
+++ b/helm_deploy/hmpps-prisoner-base-location-api/Chart.yaml
@@ -5,8 +5,8 @@ name: hmpps-prisoner-base-location-api
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: "3.12"
+    version: "3.17.2"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: "1.17"
+    version: "1.17.1"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts


### PR DESCRIPTION
Update these:
- Gradle SB plugin `10.5.7`
-  Kotlin lib `2.5.0`
- Helm charts
  - generic-service `3.17.2`
  - generic-prometheus-alerts `1.17.1`
- swagger-parser to `2.1.45`

Pin these:
- Jackson2 `2.21.5`
- log4j `2.25.5`
- tomcat `11.0.24`